### PR TITLE
sound: Set decimator volume to default in disable sequence

### DIFF
--- a/config/snd_soc_msm_2x
+++ b/config/snd_soc_msm_2x
@@ -5581,10 +5581,10 @@ SectionDevice
 	DisableSequence
 		'SLIM TX7 MUX':0:ZERO
 		'DEC4 MUX':0:ZERO
-		'DEC4 Volume':1:0
+		'DEC4 Volume':1:68
 		'SLIM TX8 MUX':0:ZERO
 		'DEC3 MUX':0:ZERO
-		'DEC3 Volume':1:0
+		'DEC3 Volume':1:68
 		'ADC3 Volume':1:0
 		'ADC4 Volume':1:0
 		'MICBIAS1 CAPLESS Switch':1:0

--- a/config/snd_soc_msm_2x_xt92x
+++ b/config/snd_soc_msm_2x_xt92x
@@ -5581,10 +5581,10 @@ SectionDevice
 	DisableSequence
 		'SLIM TX7 MUX':0:ZERO
 		'DEC4 MUX':0:ZERO
-		'DEC4 Volume':1:0
+		'DEC4 Volume':1:68
 		'SLIM TX8 MUX':0:ZERO
 		'DEC3 MUX':0:ZERO
-		'DEC3 Volume':1:0
+		'DEC3 Volume':1:68
 		'ADC3 Volume':1:0
 		'ADC4 Volume':1:0
 		'MICBIAS1 CAPLESS Switch':1:0


### PR DESCRIPTION
- setting it to zero causes mute mic in other use cases that don't
  explicitly set the decimator volume in their enable sequences

Change-Id: I8f84f631ac5275a948112a005993ede0f4070cae
